### PR TITLE
Add instructions to fix microphone issue and close blog link issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,13 @@ re-running the installation script. It knows how to finish the job.
         nameserver 8.8.8.8
         nameserver 8.8.4.4 
 
+* If the microphone doesn't work, you may need to install and run pavucontrol:
+
+        $ sudo apt install pavucontrol
+        $ pavucontrol
+
+Under the Input Devices tab, change Port to "Microphone (unplugged)".
+
 Reinstall
 ---------
 


### PR DESCRIPTION
Fixes #23. Adds instructions to install and run pavucontrol, which helps fix the microphone not working.

Fixes #17. The incorrect blog link in this issue was fixed in a previous commit.